### PR TITLE
Recursively create subdirectories when mapping.

### DIFF
--- a/lib/installer.js
+++ b/lib/installer.js
@@ -82,7 +82,7 @@ function installFile(f, pakcfg, paths, dep, silent, options, callback) {
 
     // For mapped files, create the directory if it doesn't exist
     if (f_name_new && !fileLib.existsSync(pathLib.normalize(pathLib.dirname(f_path)))) {
-        fileLib.mkdirSync(pathLib.normalize(pathLib.dirname(f_path)));
+        fileLib.mkdirSync(pathLib.normalize(pathLib.dirname(f_path)), 0777, true);
     }
 	
     // If package.json file was parsed


### PR DESCRIPTION
Allows mappings to map to files within nested subdirectories. 
Explicitly passing mode mask is required because mkdirSync has a different default from fs.mkdir
